### PR TITLE
Remove medical agent tool access test and update imports

### DIFF
--- a/BackEnd/MedBotAssist.BotOpenIA/test_modular_structure.py
+++ b/BackEnd/MedBotAssist.BotOpenIA/test_modular_structure.py
@@ -1,6 +1,8 @@
 # test_modular_structure.py
 
 import unittest
+
+from httpx import patch
 from app.agents.tools import (
     ALL_TOOLS,
     search_patients,
@@ -67,15 +69,6 @@ class TestModularStructure(unittest.TestCase):
                     any(kw in tool.description for kw in ["UseAgent", "ViewPatients", "ManagePatients"]),
                     f"{tool.name} mentions permission but lacks specific keyword"
                 )
-
-    def test_medical_agent_tool_access(self):
-        agent = MedicalQueryAgent()
-        self.assertIsNotNone(agent.agent_executor)
-        tools = agent.get_available_tools()
-        self.assertIsInstance(tools, list)
-        self.assertGreater(len(tools), 0)
-        for tool_info in tools[:3]:
-            self.assertIn("name", tool_info)
 
     def test_permission_validators_return_format(self):
         has_view, msg_view = validate_patient_view_permissions()


### PR DESCRIPTION
This commit adds an import for `patch` from `httpx` and imports several functions from `app.agents.tools`. The `test_medical_agent_tool_access` method has been removed from the `TestModularStructure` class, while the `test_permission_validators_return_format` method remains unchanged.