### PR TITLE
Remove ZIP listing step in deployment; minor cleanup

### DIFF
--- a/.github/workflows/medbotassist-botopenai-deploy.yml
+++ b/.github/workflows/medbotassist-botopenai-deploy.yml
@@ -34,9 +34,6 @@ jobs:
           cd BackEnd/MedBotAssist.BotOpenIA
           zip -r ../../../medbotopenia.zip *
 
-      - name: List ZIP contents
-        run: unzip -l medbotopenia.zip
-
       - name: Deploy to Azure Web App
         uses: azure/webapps-deploy@v2
         with:

--- a/BackEnd/MedBotAssist.BotOpenIA/main.py
+++ b/BackEnd/MedBotAssist.BotOpenIA/main.py
@@ -38,4 +38,3 @@ async def health_check():
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8000)
-    


### PR DESCRIPTION
Updated `medbotassist-botopenai-deploy.yml` to eliminate the step that lists the contents of the ZIP file for deployment, streamlining the process.

In `main.py`, made no functional changes to the `uvicorn.run` command; adjustments were likely related to formatting or whitespace.