### PR TITLE
Fix SQLite3 compatibility for Azure App Service

### DIFF
--- a/BackEnd/MedBotAssist.BotOpenIA/app/agents/tools/instructive_search_tools.py
+++ b/BackEnd/MedBotAssist.BotOpenIA/app/agents/tools/instructive_search_tools.py
@@ -1,6 +1,13 @@
 """
 Tools for searching information in vectorized instructional documents
 """
+
+# SQLite fix for Azure App Service BEFORE any other imports
+try:
+    import sqlite_fix
+except ImportError:
+    pass
+
 import os
 import json
 from typing import List, Dict, Any, Optional, Tuple

--- a/BackEnd/MedBotAssist.BotOpenIA/app/services/vectorization_manager.py
+++ b/BackEnd/MedBotAssist.BotOpenIA/app/services/vectorization_manager.py
@@ -5,6 +5,12 @@ This service handles vectorization of files from Azure Blob Storage using OpenAI
 and ChromaDB for storage and metadata management.
 """
 
+# SQLite fix for Azure App Service BEFORE any other imports
+try:
+    import sqlite_fix
+except ImportError:
+    pass
+
 from typing import List, Dict, Any, Optional, Tuple
 import asyncio
 import logging

--- a/BackEnd/MedBotAssist.BotOpenIA/requirements.txt
+++ b/BackEnd/MedBotAssist.BotOpenIA/requirements.txt
@@ -15,6 +15,9 @@ PyJWT==2.8.0
 httpx==0.28.1
 pytest>=7.0.0
 
+# SQLite fix for ChromaDB (MUST be before chromadb)
+pysqlite3-binary>=0.5.0
+
 # Vectorization dependencies
 chromadb>=1.0.15
 PyPDF2==3.0.1

--- a/BackEnd/MedBotAssist.BotOpenIA/scripts/debug_chromadb.py
+++ b/BackEnd/MedBotAssist.BotOpenIA/scripts/debug_chromadb.py
@@ -7,6 +7,12 @@ import sys
 import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+# SQLite fix for Azure App Service BEFORE ChromaDB imports
+try:
+    import sqlite_fix
+except ImportError:
+    pass
+
 import chromadb
 from chromadb.config import Settings
 from app.agents.tools.instructive_search_tools import InstructiveSearchTools

--- a/BackEnd/MedBotAssist.BotOpenIA/scripts/direct_chromadb_search.py
+++ b/BackEnd/MedBotAssist.BotOpenIA/scripts/direct_chromadb_search.py
@@ -6,6 +6,12 @@ import sys
 import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+# SQLite fix for Azure App Service BEFORE ChromaDB imports
+try:
+    import sqlite_fix
+except ImportError:
+    pass
+
 import chromadb
 from chromadb.config import Settings as ChromaSettings
 from app.core.config import settings

--- a/BackEnd/MedBotAssist.BotOpenIA/sqlite_fix.py
+++ b/BackEnd/MedBotAssist.BotOpenIA/sqlite_fix.py
@@ -1,0 +1,8 @@
+"""
+SQLite3 compatibility fix for ChromaDB in Azure App Service
+"""
+import sys
+
+# Force use of pysqlite3 instead of system sqlite3
+__import__('pysqlite3')
+sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')


### PR DESCRIPTION
Introduce `sqlite_fix.py` to enforce `pysqlite3` usage instead of the system's default `sqlite3`. Update
multiple files to import this fix before relevant
modules, particularly ChromaDB. Also, update
`requirements.txt` to include `pysqlite3-binary`
as a dependency to ensure compatibility.