### PR TITLE
Fix env variable injection in appsettings.json

### DIFF
--- a/.github/workflows/medbotassist-webapi-deploy.yml
+++ b/.github/workflows/medbotassist-webapi-deploy.yml
@@ -24,9 +24,9 @@ jobs:
            JWT_SECRET: ${{ secrets.JWT_SECRET }}
            AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
         run: |
-           sed -i 's|"MedBotAssistConnection": ""|"MedBotAssistConnection": "'"$DB_CONNECTION_STRING"'"|' BackEnd/MedBotAssist.WebApi/MedBotAssist.WebApi/appsettings.json
-           sed -i 's|"Secret": ""|"Secret": "'"$JWT_SECRET"'"|' BackEnd/MedBotAssist.WebApi/MedBotAssist.WebApi/appsettings.json
-           sed -i 's|"accountKey": ""|"accountKey": "'"$AZURE_STORAGE_KEY"'"|' BackEnd/MedBotAssist.WebApi/MedBotAssist.WebApi/appsettings.json
+           sed -i "s|\"MedBotAssistConnection\": \"\"|\"MedBotAssistConnection\": \"${DB_CONNECTION_STRING}\"|" BackEnd/MedBotAssist.WebApi/MedBotAssist.WebApi/appsettings.json
+           sed -i "s|\"Secret\": \"\"|\"Secret\": \"${JWT_SECRET}\"|" BackEnd/MedBotAssist.WebApi/MedBotAssist.WebApi/appsettings.json
+           sed -i "s|\"accountKey\": \"\"|\"accountKey\": \"${AZURE_STORAGE_KEY}\"|" BackEnd/MedBotAssist.WebApi/MedBotAssist.WebApi/appsettings.json
                  
       - name: Restore dependencies
         run: dotnet restore BackEnd/MedBotAssist.WebApi/MedBotAssist.WebApi.sln


### PR DESCRIPTION
Updated `medbotassist-webapi-deploy.yml` to use double quotes in `sed` commands for environment variable expansion. This change allows `DB_CONNECTION_STRING`, `JWT_SECRET`, and `AZURE_STORAGE_KEY` to be correctly injected into the `appsettings.json` file.