### PR TITLE
Refactor InstructiveSearchTools initialization

### DIFF
--- a/BackEnd/MedBotAssist.BotOpenIA/app/agents/tools/instructive_search_tools.py
+++ b/BackEnd/MedBotAssist.BotOpenIA/app/agents/tools/instructive_search_tools.py
@@ -244,23 +244,27 @@ Respond clearly and professionally based solely on the information provided."""
                 'results': []
             }
 
-# Global instance to use in the agent - will be initialized after vectorization_manager is available
-instructive_search_tools = InstructiveSearchTools()
+# Global instance to use in the agent - will be initialized lazily
+instructive_search_tools = None
 
 # Initialize with the global vectorization manager
-def _initialize_instructive_tools():
-    """Initialize instructive tools with the global vectorization manager."""
-    try:
-        print("DEBUG: Attempting to initialize instructive tools...")
-        from app.services.vectorization_manager import get_vectorization_manager
-        vectorization_manager = get_vectorization_manager()
-        print(f"DEBUG: Got vectorization_manager singleton with {vectorization_manager.get_document_count()} documents")
-        instructive_search_tools.set_vectorization_manager(vectorization_manager)
-        print("DEBUG: Successfully initialized instructive tools")
-    except Exception as e:
-        print(f"Warning: Could not initialize instructive tools: {e}")
-        import traceback
-        traceback.print_exc()
+def _get_instructive_tools():
+    """Get initialized instructive tools with the vectorization manager."""
+    global instructive_search_tools
+    if instructive_search_tools is None:
+        print("DEBUG: Creating new InstructiveSearchTools instance...")
+        instructive_search_tools = InstructiveSearchTools()
+        try:
+            from app.services.vectorization_manager import get_vectorization_manager
+            vectorization_manager = get_vectorization_manager()
+            print(f"DEBUG: Got vectorization_manager singleton with {vectorization_manager.get_document_count()} documents")
+            instructive_search_tools.set_vectorization_manager(vectorization_manager)
+            print("DEBUG: Successfully initialized instructive tools")
+        except Exception as e:
+            print(f"Warning: Could not initialize instructive tools: {e}")
+            import traceback
+            traceback.print_exc()
+    return instructive_search_tools
 
 # LangChain tools to use in the medical agent
 @tool
@@ -279,20 +283,19 @@ def search_instructive_info(query: str) -> str:
         Information found in medical instructional documents with cited sources
     """
     try:
-        # Ensure vectorization manager is initialized
-        if not instructive_search_tools.vectorization_manager:
-            _initialize_instructive_tools()
+        # Get initialized tools instance
+        tools = _get_instructive_tools()
         
         # Check if vectorization manager is available
-        if not instructive_search_tools.vectorization_manager:
+        if not tools.vectorization_manager:
             return "No vectorized instructional documents available in the system."
         
-        document_count = instructive_search_tools._get_document_count()
+        document_count = tools._get_document_count()
         if document_count == 0:
             return "No vectorized instructional documents available in the system."
         
         # Search for documents
-        results = instructive_search_tools._search_documents(query, max_results=5)
+        results = tools._search_documents(query, max_results=5)
         
         if not results:
             return "No relevant information found in the instructional documents for your query."
@@ -319,7 +322,7 @@ QUESTION: {query}
 
 Respond clearly and professionally based solely on the information provided."""
 
-        response = instructive_search_tools.openai_client.chat.completions.create(
+        response = tools.openai_client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[{"role": "system", "content": system_prompt}],
             max_tokens=500,
@@ -351,25 +354,23 @@ def get_available_instructives_list() -> str:
         List of available medical instructional documents with details
     """
     try:
-        # Ensure vectorization manager is initialized
+        # Get initialized tools instance
         print("DEBUG: get_available_instructives_list called")
-        if not instructive_search_tools.vectorization_manager:
-            print("DEBUG: No vectorization manager, attempting to initialize...")
-            _initialize_instructive_tools()
+        tools = _get_instructive_tools()
         
         # Check if vectorization manager is available
-        if not instructive_search_tools.vectorization_manager:
-            print("DEBUG: Still no vectorization manager after initialization")
+        if not tools.vectorization_manager:
+            print("DEBUG: Still no vectorization manager after getting tools")
             return "No vectorization system available."
         
-        document_count = instructive_search_tools._get_document_count()
+        document_count = tools._get_document_count()
         print(f"DEBUG: Document count: {document_count}")
         if document_count == 0:
             return "No instructional documents have been vectorized yet."
         
         # Get unique files from documents
         files_info = {}
-        for doc_id, doc in instructive_search_tools.vectorization_manager.documents.items():
+        for doc_id, doc in tools.vectorization_manager.documents.items():
             filename = doc.metadata.get('filename', 'unknown')
             file_type = doc.metadata.get('file_type', 'unknown')
             

--- a/BackEnd/MedBotAssist.BotOpenIA/app/api/routes/vectorization.py
+++ b/BackEnd/MedBotAssist.BotOpenIA/app/api/routes/vectorization.py
@@ -18,12 +18,14 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 # Initialize services
-vectorization_manager = VectorizationManager()
+from app.services.vectorization_manager import get_vectorization_manager
+vectorization_manager = get_vectorization_manager()
 jwt_service = JWTService()
 
 # Initialize instructive search tools and connect with vectorization manager
-from app.agents.tools.instructive_search_tools import instructive_search_tools
-instructive_search_tools.set_vectorization_manager(vectorization_manager)
+from app.agents.tools.instructive_search_tools import _get_instructive_tools
+instructive_tools = _get_instructive_tools()
+# No need to set vectorization manager again since _get_instructive_tools already does it
 
 def validate_jwt_and_permissions(authorization: str) -> Dict[str, Any]:
     """
@@ -262,7 +264,7 @@ async def search_instructives(
         user_info = validate_jwt_and_permissions(authorization)
         
         # Use the instructive search tools
-        result = instructive_search_tools.search_instructive_information(
+        result = instructive_tools.search_instructive_information(
             query=query,
             max_results=max_results,
             min_similarity=min_similarity
@@ -315,7 +317,7 @@ async def get_available_instructives(
         # Validate JWT and permissions
         user_info = validate_jwt_and_permissions(authorization)
         
-        result = instructive_search_tools.get_available_instructives()
+        result = instructive_tools.get_available_instructives()
         result["requested_by"] = user_info["username"]
         
         logger.info(f"Retrieved {result.get('total_files', 0)} available instructives for '{user_info['username']}'")
@@ -366,7 +368,7 @@ async def search_by_filename(
         # Validate JWT and permissions
         user_info = validate_jwt_and_permissions(authorization)
         
-        result = instructive_search_tools.search_by_filename(filename=filename, query=query)
+        result = instructive_tools.search_by_filename(filename=filename, query=query)
         result["requested_by"] = user_info["username"]
         
         logger.info(f"Search in file '{filename}' with query '{query}' by '{user_info['username']}' returned {result.get('total_chunks', 0)} chunks")


### PR DESCRIPTION
- Implement lazy initialization for the `InstructiveSearchTools` instance using `_get_instructive_tools()`.
- Remove the `_initialize_instructive_tools()` function and integrate its logic into the new function.
- Update `search_instructive_info` and `get_available_instructives_list` to use the new `tools` variable for consistency.
- Replace import of `instructive_search_tools` in `vectorization.py` with `_get_instructive_tools()` and use `instructive_tools` throughout.
- Ensure all relevant functions utilize the latest instance of the tools for improved reliability.